### PR TITLE
Change Province names from having only capital letters

### DIFF
--- a/data/provinces.json
+++ b/data/provinces.json
@@ -1,12 +1,12 @@
 {
-  "AB": "ALBERTA",
-  "BC": "BRITISH COLUMBIA",
-  "MB": "MANITOBA",
-  "NB": "NEW BRUNSWICK",
-  "NL": "NEWFOUNDLAND AND LABRADOR",
-  "NS": "NOVA SCOTIA",
-  "ON": "ONTARIO",
-  "PE": "PRINCE EDWARD ISLAND",
-  "QC": "QUEBEC",
-  "SK": "SASKATCHEWAN"
+  "AB": "Alberta",
+  "BC": "British Columbia",
+  "MB": "Manitoba",
+  "NB": "New Brunswick",
+  "NL": "Newfoundland and Labrador",
+  "NS": "Nova Scotia",
+  "ON": "Ontario",
+  "PE": "Prince Edward Island",
+  "QC": "Quebec",
+  "SK": "Saskatchewan"
 }


### PR DESCRIPTION
This makes it consistent with the territories which already have English-proper capitalization.  (I would also like to do this with the city names, but there are more than 7,000 in the list so I would have to look into working on this later.)