### PR TITLE
Changing to proper sentence casing.

### DIFF
--- a/data/provinces.json
+++ b/data/provinces.json
@@ -1,12 +1,12 @@
 {
-  "AB": "ALBERTA",
-  "BC": "BRITISH COLUMBIA",
-  "MB": "MANITOBA",
-  "NB": "NEW BRUNSWICK",
-  "NL": "NEWFOUNDLAND AND LABRADOR",
-  "NS": "NOVA SCOTIA",
-  "ON": "ONTARIO",
-  "PE": "PRINCE EDWARD ISLAND",
-  "QC": "QUEBEC",
-  "SK": "SASKATCHEWAN"
+  "AB": "Alberta",
+  "BC": "British Columbia",
+  "MB": "Manitoba",
+  "NB": "New Brunswick",
+  "NL": "Newfoundland and Labrador",
+  "NS": "Nova Scotia",
+  "ON": "Ontario",
+  "PE": "Prince Edward Island",
+  "QC": "Quebec",
+  "SK": "Saskatchewan"
 }


### PR DESCRIPTION
Because it is very easy to change proper sentence casing into upper case, lower case, and first letter of each word capitalization it is optimal to store test strings in true Title case. This is because it is very difficult to format strings into proper title case.

This allows the string to be used in proper title case that can easily be changed to fit the users styling. But then if the styling required is title case it's formatted as such.